### PR TITLE
Pull proxy attr from correct object _meta

### DIFF
--- a/curation/models.py
+++ b/curation/models.py
@@ -240,7 +240,7 @@ class CuratedItem(models.Model):
                 self.__getattribute__(curated_field_name)
                 proxy_attrs = self.__dict__.get('_proxy_attrs', [])
         else:
-            proxy_attrs = getattr(self._meta, '_proxy_attrs', [])
+            proxy_attrs = getattr(getattr(self, curated_field_name)._meta, '_proxy_attrs', [])
 
         if attr in proxy_attrs:
             try:
@@ -275,6 +275,5 @@ class CuratedItem(models.Model):
                                     "model_name": self._meta.object_name,
                                     "fk_str": fk_str,
                                 })
-
         raise AttributeError("'%s' object has no attribute '%s'" % \
             (self.__class__.__name__, attr))


### PR DESCRIPTION
Proxy attrs live on the original object, not the curated
version of that object.